### PR TITLE
Support loading from multiple config paths in order

### DIFF
--- a/scruffy/env.py
+++ b/scruffy/env.py
@@ -97,7 +97,7 @@ class Environment(object):
                     if 'basename_variable' in self.files[name] and self.files[name]['basename_variable'] in os.environ:
                         bn = os.environ[self.files[name]['basename_variable']].replace("/", '')
                         if len(bn) > 0:
-                            if len(self.basename) > MAX_BASENAME:
+                            if len(bn) > MAX_BASENAME:
                                 bn = bn[-MAX_BASENAME:]
                             self.basename = bn
                 elif fspec['type'] == 'json':


### PR DESCRIPTION
This makes breaking changes to the API, so updating apps will need to be
coordinated/needs a version bump

The reason for the breaking change is that the config keys need to be ordered, otherwise you'll get faux-random config file precendence.
