### PR TITLE
Improved py2 py3 string compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
-  - "3.6"
-  - "3.7"
 install:
   - pip install .
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install .
   - pip install -r requirements.txt

--- a/scruffy/config.py
+++ b/scruffy/config.py
@@ -4,12 +4,14 @@ Config
 
 Classes for loading and accessing configuration data.
 """
+from __future__ import unicode_literals
 import copy
 import os
 import ast
 import yaml
 import re
 
+from six import string_types
 from .file import File
 
 
@@ -145,7 +147,7 @@ class ConfigNode(object):
         the item referred to by the key path.
         """
         # Split up the key path
-        if type(self._path) == str:
+        if isinstance(self._path, string_types):
             key_path = self._path.split('.')
         else:
             key_path = [self._path]
@@ -295,7 +297,7 @@ class ConfigFile(Config, File):
         """
         if reload or not self._loaded:
             # load defaults
-            if self._defaults_file and type(self._defaults_file) == str:
+            if self._defaults_file and isinstance(self._defaults_file, string_types):
                 self._defaults_file = File(self._defaults_file, parent=self._parent)
             defaults = {}
             if self._defaults_file:
@@ -343,7 +345,7 @@ class ConfigApplicator(object):
         """
         Apply the config to an object.
         """
-        if type(obj) == str:
+        if isinstance(obj, str):
             return self.apply_to_str(obj)
 
     def apply_to_str(self, obj):

--- a/scruffy/config.py
+++ b/scruffy/config.py
@@ -80,9 +80,6 @@ class ConfigNode(object):
     def __le__(self, other):
         return self._get_value() <= other
 
-    def __le__(self, other):
-        return self._get_value() <= other
-
     def __eq__(self, other):
         return self._get_value() == other
 

--- a/scruffy/env.py
+++ b/scruffy/env.py
@@ -16,7 +16,7 @@ from six import string_types
 
 from .file import Directory
 from .plugin import PluginManager
-from .config import ConfigNode, Config, ConfigEnv, ConfigApplicator
+from .config import ConfigNode, Config, ConfigEnv, ConfigApplicator, ConfigFile
 
 
 class Environment(object):

--- a/scruffy/env.py
+++ b/scruffy/env.py
@@ -12,6 +12,8 @@ import errno
 import logging
 import logging.config
 
+from six import string_types
+
 from .file import Directory
 from .plugin import PluginManager
 from .config import ConfigNode, Config, ConfigEnv, ConfigApplicator
@@ -68,7 +70,7 @@ class Environment(object):
 
         # first see if we got a kwarg named 'config', as this guy is special
         if 'config' in children:
-            if type(children['config']) == str:
+            if isinstance(children['config'], string_types):
                 children['config'] = ConfigFile(children['config'])
             elif isinstance(children['config'], Config):
                 children['config'] = children['config']
@@ -103,7 +105,7 @@ class Environment(object):
         Add objects to the environment.
         """
         for key in kwargs:
-            if type(kwargs[key]) == str:
+            if isinstance(kwargs[key], string_types):
                 self._children[key] = Directory(kwargs[key])
             else:
                 self._children[key] = kwargs[key]

--- a/scruffy/file.py
+++ b/scruffy/file.py
@@ -4,7 +4,11 @@ File
 
 Classes for representing and performing operations on files and directories.
 """
+from __future__ import unicode_literals
+from builtins import str
+from builtins import object
 import os
+from six import string_types
 import yaml
 import copy
 import logging
@@ -46,7 +50,7 @@ class File(object):
         """
         Replace any config tokens in the file's path with values from the config.
         """
-        if type(self._fpath) == str:
+        if isinstance(self._fpath, string_types):
             self._fpath = applicator.apply(self._fpath)
 
     def create(self):
@@ -172,7 +176,7 @@ class LogFile(File):
 
         # if we got a string for the formatter, assume it's the name of a
         # formatter in the environment's config
-        if type(self._formatter) == str:
+        if isinstance(self._format, string_types):
             if self._env and self._env.config.logging.dict_config.formatters[self._formatter]:
                 d = self._env.config.logging.dict_config.formatters[self._formatter].to_dict()
                 handler.setFormatter(logging.Formatter(**d))
@@ -267,7 +271,7 @@ class Directory(object):
         self._env = None
         self._parent = parent
 
-        if self._path and type(self._path) == str:
+        if self._path and isinstance(self._path, string_types):
             self._path = os.path.expanduser(self._path)
 
         self.add(**kwargs)
@@ -289,7 +293,7 @@ class Directory(object):
         """
         Replace any config tokens with values from the config.
         """
-        if type(self._path) == str:
+        if isinstance(self._path, string_types):
             self._path = applicator.apply(self._path)
 
         for key in self._children:
@@ -396,7 +400,7 @@ class Directory(object):
         Add objects to the directory.
         """
         for key in kwargs:
-            if isinstance(kwargs[key], str):
+            if isinstance(kwargs[key], string_types):
                 self._children[key] = File(kwargs[key])
             else:
                 self._children[key] = kwargs[key]
@@ -409,7 +413,7 @@ class Directory(object):
                 self._children[arg.name] = arg
                 self._children[arg.name]._parent = self
                 self._children[arg.name]._env = self._env
-            elif isinstance(arg, str):
+            elif isinstance(arg, string_types):
                 f = File(arg)
                 added.append(f)
                 self._children[arg] = f

--- a/scruffy/file.py
+++ b/scruffy/file.py
@@ -5,8 +5,6 @@ File
 Classes for representing and performing operations on files and directories.
 """
 from __future__ import unicode_literals
-from builtins import str
-from builtins import object
 import os
 from six import string_types
 import yaml

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -1,5 +1,6 @@
 import yaml
 import os
+from six import string_types
 
 from nose.tools import *
 from scruffy import *
@@ -41,7 +42,7 @@ def test_config_object_set():
     c.derp1 = {'a': [1,2,3], 'b': 'xxx'}
     assert c.derp1.a[0] == 1
     assert c.derp1.b == 'xxx'
-    assert type(c.derp1.b) == str
+    assert isinstance(c.derp1.b, string_types)
     c['derp2.a.b.c'] = 123
     assert c.derp2.a.b.c == 123
     c.derp3.a.b.c = 666


### PR DESCRIPTION
Fix several instances of string type checking, by replacing `type()` with `isintance(obj, string_types)`

String type checking was failing when called from code that uses future-compatible string classes

Also fix a couple small, but potentially critical bugs the linter caught:

- `ConfigFile` used but not imported in `env.py`
- `ConfigNode.__le__()` defined twice