### PR TITLE
Save state atexit

### DIFF
--- a/scruffy/state.py
+++ b/scruffy/state.py
@@ -5,7 +5,9 @@ State
 Classes for storing a program's state.
 """
 import os
+import atexit
 import yaml
+
 
 try:
     from sqlalchemy import create_engine, Column, Integer, String
@@ -34,6 +36,7 @@ class State(object):
         self.path = path
         self.d = {}
         self.load()
+        atexit.register(self._exit_handler)
 
     def __enter__(self):
         self.load()
@@ -50,6 +53,9 @@ class State(object):
 
     def __setitem__(self, key, value):
         self.d[key] = value
+
+    def _exit_handler(self):
+        self.save()
 
     def save(self):
         """

--- a/scruffy/state.py
+++ b/scruffy/state.py
@@ -70,11 +70,7 @@ class State(object):
         """
         if os.path.exists(self.path):
             with open(self.path, 'r') as f:
-                d = yaml.safe_load(f.read().replace('\t', ' '*4))
-                # don't clobber self.d if we successfully opened the state file
-                # but it was empty
-                if d:
-                    self.d = d
+                self.d = yaml.safe_load(f.read().replace('\t', ' '*4))
 
     def cleanup(self):
         """

--- a/scruffy/state.py
+++ b/scruffy/state.py
@@ -64,7 +64,11 @@ class State(object):
         """
         if os.path.exists(self.path):
             with open(self.path, 'r') as f:
-                self.d = yaml.safe_load(f.read().replace('\t', ' '*4))
+                d = yaml.safe_load(f.read().replace('\t', ' '*4))
+                # don't clobber self.d if we successfully opened the state file
+                # but it was empty
+                if d:
+                    self.d = d
 
     def cleanup(self):
         """


### PR DESCRIPTION
Register an `atexit` handler so state gets saved on program termination.

This allows `State` to be used in forms other than:
```
with State() as s:
    do_stuff()
```
Without this, state wasn't always getting saved