### PR TITLE
Init empty state

### DIFF
--- a/scruffy/state.py
+++ b/scruffy/state.py
@@ -64,7 +64,11 @@ class State(object):
         """
         if os.path.exists(self.path):
             with open(self.path, 'r') as f:
-                self.d = yaml.safe_load(f.read().replace('\t', ' '*4))
+                d = yaml.safe_load(f.read().replace('\t', ' '*4))
+                # don't clobber self.d if we successfully opened the state file
+                # but it was empty
+                if d:
+                    self.d = d
 
     def cleanup(self):
         """


### PR DESCRIPTION
If we load with an empty YAML state file, `d` will be `None`, so don't clobber `self.d`.