### PR TITLE
Add python 3.6, 3.7 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install .
   - pip install -r requirements.txt


### PR DESCRIPTION
Hopefully with pyaml updated, we can test against newer pythons.