### PR TITLE
Add Power Support ppc64le and python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-arch:
+arch: 
   - amd64
   - ppc64le
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
+arch:
+  - amd64
+  - ppc64le
 install:
   - pip install .
   - pip install -r requirements.txt


### PR DESCRIPTION
Added recent python version and power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.